### PR TITLE
Fix api endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ dist
 .DS_Store
 scripts/*.json
 scripts/*.csv
+
+.vercel

--- a/pages/api/getLocationsTest.js
+++ b/pages/api/getLocationsTest.js
@@ -1,4 +1,4 @@
-var quizQuestions = [
+const testLocations = [
     {
         "id": 1,
         "lat": -1.91656,
@@ -85,5 +85,14 @@ var quizQuestions = [
     }
 ]
 
-
-export default quizQuestions;
+export default async (req, res) => {
+	if (req.method === 'GET') {
+		res.statusCode = 200;
+		res.setHeader('Content-Type', 'application/json');
+		res.end(JSON.stringify(testLocations));
+	} else {
+		// If it's not a GET request, return 405 - Method Not Allowed
+		res.statusCode = 405;
+		res.end();
+	}
+}

--- a/pages/start-test.js
+++ b/pages/start-test.js
@@ -1,19 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useCookies } from 'react-cookie';
 import { v4 as uuidv4 } from 'uuid';
-
 import Head from 'next/head';
 import Link from 'next/link';
-
-
 import { Container, Col, Row, Button } from 'react-bootstrap';
-
 
 import useScriptText from '../hooks/useScriptText';
 import Intro from '../components/intro';
 import QuizTest from '../components/quizTest';
-import quizQuestions from '../api/quizQuestions';
-
 import Layout from '../components/layout';
 import HeaderComponent from '../components/headerComponent';
 

--- a/pages/summary.js
+++ b/pages/summary.js
@@ -8,7 +8,6 @@ import { Container, Table } from 'react-bootstrap';
 import useScriptText from '../hooks/useScriptText';
 import Intro from '../components/intro';
 import Quiz from '../components/quiz';
-import quizQuestions from '../api/quizQuestions';
 import Result from '../components/result';
 
 

--- a/pages/test.js
+++ b/pages/test.js
@@ -5,9 +5,10 @@ import { v4 as uuidv4 } from 'uuid';
 import useScriptText from '../hooks/useScriptText';
 import Intro from '../components/intro';
 import QuizTest from '../components/quizTest';
-import quizQuestions from '../api/quizQuestions';
+//import quizQuestions from '../api/quizQuestions';
 import ResultTest from '../components/resultTest';
 
+const quizQuestions = [];
 
 const numQuestions = 6;
  
@@ -33,13 +34,18 @@ export default function mapping() {
 	}
 
 	useEffect(() => {
-		// Initialize the set of questions
-		setQuestions(shuffle(quizQuestions));
-
 		// Initialize cookie if not present
 		if(!cookies.uuid){
 			setCookie('uuid', uuidv4(), { path: '/' });
 		}
+
+		// Initialize the set of questions
+		async function fetchData() {
+			// Get location data
+			const result = await fetch(`/api/getLocationsTest`);
+			setQuestions(shuffle(await result.json()));
+		}
+		fetchData();
 
 	}, []);
 


### PR DESCRIPTION
In the production environment a new warning appeared that caused the deployment to fail, namely:
```
│ WARN! It is not possible to use `api` and `pages/api` at the same time, please only use one option │
```
This was a known issue, but hadn't posed problems until now. Thus the code has been refactored to move `api/quizQuestions.js` to `pages/api/getLocationsTest.js`