### PR TITLE
Custom model fix

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -1,60 +1,60 @@
 
 export default class User {
-	constructor(name, email, image, emailVerified) {
-		if (name) {
-			this.name = name;
-		}
-		if (email) {
-			this.email = email;
-		}
-		if (image) {
-			this.image = image;
-		}
-		if (emailVerified) {
-			const currentDate = new Date();
-			this.emailVerified = currentDate;
-		}
-	}
+    constructor(name, email, image, emailVerified) {
+        if (name) {
+            this.name = name;
+        }
+        if (email) {
+            this.email = email;
+        }
+        if (image) {
+            this.image = image;
+        }
+        if (emailVerified) {
+            const currentDate = new Date();
+            this.emailVerified = currentDate;
+        }
+    }
 }
 
 export const UserSchema = {
-	name: 'User',
-	target: User,
-	columns: {
-		id: {
-			primary: true,
-			type: 'int',
-			generated: true,
-		},
-		name: {
-			type: 'varchar',
-			nullable: true,
-		},
-		email: {
-			type: 'varchar',
-			unique: true,
-			nullable: true,
-		},
-		emailVerified: {
-			type: 'timestamp',
-			nullable: true,
-		},
-		image: {
-			type: 'varchar',
-			nullable: true,
-		},
-		createdAt: {
-			type: 'timestamp',
-			createDate: true,
-		},
-		updatedAt: {
-			type: 'timestamp',
-			updateDate: true,
-		},
-		// Extend the default model with uuid
-		uuid: {
-			type: 'varchar',
-			nullable: true,
-		},
-	},
+    name: 'User',
+    target: User,
+    columns: {
+        id: {
+            primary: true,
+            type: 'int',
+            generated: true,
+        },
+        name: {
+            type: 'varchar',
+            nullable: true,
+        },
+        email: {
+            type: 'varchar',
+            unique: true,
+            nullable: true,
+        },
+        emailVerified: {
+            type: 'timestamp',
+            nullable: true,
+        },
+        image: {
+            type: 'varchar',
+            nullable: true,
+        },
+        createdAt: {
+            type: 'timestamp',
+            createDate: true,
+        },
+        updatedAt: {
+            type: 'timestamp',
+            updateDate: true,
+        },
+        // Extend the default model with uuid
+        uuid: {
+            type: 'varchar',
+            nullable: true,
+        },
+    },
 };

--- a/models/User.js
+++ b/models/User.js
@@ -1,20 +1,60 @@
-import Adapters from "next-auth/adapters"
 
-export default class User extends Adapters.TypeORM.Models.User.model {
-  constructor(name, email, image, emailVerified) {
-    super(name, email, image, emailVerified)
-  }
+export default class User {
+	constructor(name, email, image, emailVerified) {
+		if (name) {
+			this.name = name;
+		}
+		if (email) {
+			this.email = email;
+		}
+		if (image) {
+			this.image = image;
+		}
+		if (emailVerified) {
+			const currentDate = new Date();
+			this.emailVerified = currentDate;
+		}
+	}
 }
 
 export const UserSchema = {
-  name: "User",
-  target: User,
-  columns: {
-    ...Adapters.TypeORM.Models.User.schema.columns,
-    //  Adds uuid to the User schema
-    uuid: {
-      type: "varchar",
-      nullable: true,
-    },
-  },
-}
+	name: 'User',
+	target: User,
+	columns: {
+		id: {
+			primary: true,
+			type: 'int',
+			generated: true,
+		},
+		name: {
+			type: 'varchar',
+			nullable: true,
+		},
+		email: {
+			type: 'varchar',
+			unique: true,
+			nullable: true,
+		},
+		emailVerified: {
+			type: 'timestamp',
+			nullable: true,
+		},
+		image: {
+			type: 'varchar',
+			nullable: true,
+		},
+		createdAt: {
+			type: 'timestamp',
+			createDate: true,
+		},
+		updatedAt: {
+			type: 'timestamp',
+			updateDate: true,
+		},
+		// Extend the default model with uuid
+		uuid: {
+			type: 'varchar',
+			nullable: true,
+		},
+	},
+};

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -33,7 +33,7 @@ export default (req, res) => {
         // https://next-auth.js.org/schemas/adapters
         adapter: Adapters.TypeORM.Adapter(DATABASE_URL, {
             models: {
-                users: Models.users,
+                User: Models.User,
             },
         }),
 


### PR DESCRIPTION
Again circling back to #32.

Previous fix was unable to fetch uuid values from `users`-table.

This fix comes from thread [https://github.com/nextauthjs/next-auth/issues/710](https://github.com/nextauthjs/next-auth/issues/710). Extending the TypeORM User-model resulted in issues in relation naming on production builds. This fix constructs the model from scratch.

Tested on both dev environment and production builds (`next build` -> `next start`) and works well.