### PR TITLE
Users who want to replay the game will replay automatically rather than returning to welcome screen

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -59,7 +59,7 @@ export default function Result(props) {
 						<p style={{paddingTop: '.5em'}}>
 						{props.taggedAllLocations ? '🏆 You are a mapping champion! 🗺 You have mapped all of our potential school locations. We will add more shortly, so come back soon.' : 'Help us connect more children to opportunity by mapping more schools.'}
 						</p>
-						{props.taggedAllLocations ? <Button variant="primary" href="https://projectconnect.world">Visit Project Connect</Button> : <Button variant="primary" href="/">Map More Schools</Button>}
+						{props.taggedAllLocations ? <Button variant="primary" href="https://projectconnect.world">Visit Project Connect</Button> : <Button variant="primary" href="/mapping">Map More Schools</Button>}
 					</div>
 				</div>
 		    </Layout>


### PR DESCRIPTION
## What & How

To prevent users who have just repeated the game and want to replay from returning to the home screen as suggested in #47, I have set the "map more schools" button to return the user to the `/mapping` page as suggested [here](https://github.com/lacabra/proco-map-app/issues/47#issuecomment-793052291).

## Tests

After performing the changes, I have played the game and verified that the button to play again brought me directly to map more schools rather than to the welcome screen.