### PR TITLE
BLD: add country name overlay to map

### DIFF
--- a/components/quiz.js
+++ b/components/quiz.js
@@ -59,10 +59,13 @@ export default function Quiz (props) {
 			</Head>
 			<main>
 				<QuestionCount counter={props.counter} total={props.questionTotal} />
-				<p>Does this location in <b>{countryName}</b> look like a school?</p>
+				<p>Does this location look like a school?</p>
 
 				<div className="row no-gutters align-items-center mapdiv">
 					<MapComponent lat={props.question.lat} lon={props.question.lon} />
+					<div id="countryName">
+						{countryName}
+					</div>
 					<div className={answerClass}>
 						{answer['answer']}
 					</div>

--- a/components/quizTest.js
+++ b/components/quizTest.js
@@ -4,7 +4,10 @@ import dynamic from 'next/dynamic'
 import {Row, Col, Button} from 'react-bootstrap';
 
 import QuestionCount from '../components/questionCount';
-import Layout from '../components/layout'
+import Layout from '../components/layout';
+
+const countryCodes = require('../data/countries.json');
+
 
 const MapComponent = dynamic(import('../components/mapComponent'),{
 	ssr: false
@@ -53,6 +56,7 @@ export default function QuizTest (props) {
 
 	const latlon = [props.question.lat, props.question.lon];
 	const answerClass = "answer " + answer.answerClass
+	const countryName = countryCodes[props.question.country_code];
 
 	return (
 		<Layout myClass="quiz">
@@ -65,6 +69,9 @@ export default function QuizTest (props) {
 
 				<div className="row no-gutters align-items-center mapdiv">
 					<MapComponent lat={props.question.lat} lon={props.question.lon} />
+					<div id="countryName">
+						{countryName}
+					</div>
 					<div className={answerClass}>
 						{answer['answer']}
 					</div>

--- a/pages/api/getLocationsTest.js
+++ b/pages/api/getLocationsTest.js
@@ -3,85 +3,99 @@ const testLocations = [
         "id": 1,
         "lat": -1.91656,
         "lon": 30.10833,
-        "answer": true
+        "answer": true,
+        "country_code": "RW"
     },
     {
         "id": 2,
         "lat": -1.925156,
         "lon": 30.110281,
-        "answer": false
+        "answer": false,
+        "country_code": "RW"
     },
     {
         "id": 3,
         "lat": -2.02617,
         "lon": 30.02317,
-        "answer": true
+        "answer": true,
+        "country_code": "RW"
     },
     {
         "id": 4,
         "lat": -2.033803,
         "lon": 30.022977,
-        "answer": false
+        "answer": false,
+        "country_code": "RW"
     },
     {
         "id": 5,
         "lat": 17.08438244,
         "lon": -61.7566271,
-        "answer": true
+        "answer": true,
+        "country_code": "AG"
     },
     {
         "id": 6,
         "lat": 17.082966,
         "lon": -61.752061,
-        "answer": false
+        "answer": false,
+        "country_code": "AG"
     },
     {
         "id": 7,
         "lat": 17.08027778,
         "lon": -61.8325,
-        "answer": true
+        "answer": true,
+        "country_code": "AG"
     },
     {
         "id": 8,
         "lat": 17.078865,
         "lon": -61.829458,
-        "answer": false
+        "answer": false,
+        "country_code": "AG"
     },
     {
         "id": 9,
         "lat": 50.637477,
         "lon": 71.457674,
-        "answer": true
+        "answer": true,
+        "country_code": "KZ"
     },
     {
         "id": 10,
         "lat": 50.638657,
         "lon": 71.455382,
-        "answer": false
+        "answer": false,
+        "country_code": "KZ"
     },
     {
         "id": 11,
         "lat": 50.285003,
         "lon": 57.16979,
-        "answer": true
+        "answer": true,
+        "country_code": "KZ"
     },
     {
         "id": 12,
         "lat": 50.271741,
         "lon": 57.168882,
-        "answer": false
+        "answer": false,
+        "country_code": "KZ"
     },
     {
         "id": 13,
         "lat": 13.1449,
         "lon": -61.1946,
-        "answer": true
+        "answer": true,
+        "country_code": "VC"
     },
     {
         "id": 14,
         "lat": 13.141533,
         "lon": -61.194906,
-        "answer": false
+        "answer": false,
+        "country_code": "VC"
     }
 ]
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -270,6 +270,7 @@ main {
 .mapdiv {
   width: 100%;
   height: calc(100% - 8em);
+  position: relative;
 }
 
 a, .blueText {
@@ -365,6 +366,19 @@ a {
 .actionButton.maybe:hover:not([disabled]), .actionButton.maybe.btn-primary {
   color: #ffffff;
   background-color: #fec84c;
+}
+
+#countryName {
+  background-color: rgb(249, 249, 249);
+  opacity: 0.95;
+  position: absolute;
+  padding: 5px 10px;
+  z-index: 1;
+  top: 10px;
+  left: 10px;
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  font-family: 'Open Sans', sans-serif;
 }
 
 /*


### PR DESCRIPTION
Fixes #65

Implements country name overlay in both the actual mapping game, and the testing exercise (testing data was missing country data, which has been added).

Until we have a better design, this may do:

![Screen Shot 2021-04-07 at 5 07 08 PM](https://user-images.githubusercontent.com/6098973/113945541-c2f22c80-97c3-11eb-9b26-a625b839f232.png)

