### PR TITLE
BLD: theme for country label overlay

### DIFF
--- a/components/countryNameLabel.js
+++ b/components/countryNameLabel.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const CountryNameLabel = ({ countryName }) => {
+    return (
+        <div id="countryName">
+            <img style={{paddingBottom:'0.2em'}} src="icons/location-blue.svg" width="14"></img>&nbsp;             
+            {countryName}
+        </div>
+    )
+}
+
+export default CountryNameLabel

--- a/components/intro.js
+++ b/components/intro.js
@@ -3,8 +3,8 @@ import { useCookies } from 'react-cookie';
 import { useSession } from 'next-auth/client';
 import Head from 'next/head';
 import Link from 'next/link';
-import Layout from '../components/layout';
-import HeaderComponent from '../components/headerComponent';
+import Layout from './layout';
+import HeaderComponent from './headerComponent';
 import {Accordion, AccordionContext, Button, useAccordionToggle, Card} from 'react-bootstrap';
 
 function ContextAwareToggle({ children, eventKey, callback }) {

--- a/components/quiz.js
+++ b/components/quiz.js
@@ -6,7 +6,7 @@ import {Row, Col, Button} from 'react-bootstrap';
 import ProgressBar from '../components/progressBar';
 import QuestionCount from '../components/questionCount';
 import Layout from '../components/layout';
-import CountryNameLabel from '../components/countrynamelabel';
+import CountryNameLabel from '../components/countryNameLabel';
 
 const countryCodes = require('../data/countries.json');
 

--- a/components/quiz.js
+++ b/components/quiz.js
@@ -5,7 +5,8 @@ import {Row, Col, Button} from 'react-bootstrap';
 
 import ProgressBar from '../components/progressBar';
 import QuestionCount from '../components/questionCount';
-import Layout from '../components/layout'
+import Layout from '../components/layout';
+import CountryNameLabel from '../components/countrynamelabel';
 
 const countryCodes = require('../data/countries.json');
 
@@ -63,9 +64,7 @@ export default function Quiz (props) {
 
 				<div className="row no-gutters align-items-center mapdiv">
 					<MapComponent lat={props.question.lat} lon={props.question.lon} />
-					<div id="countryName">
-						{countryName}
-					</div>
+					<CountryNameLabel countryName={countryName} />
 					<div className={answerClass}>
 						{answer['answer']}
 					</div>

--- a/components/quiz.js
+++ b/components/quiz.js
@@ -3,14 +3,14 @@ import Head from 'next/head';
 import dynamic from 'next/dynamic'
 import {Row, Col, Button} from 'react-bootstrap';
 
-import ProgressBar from '../components/progressBar';
-import QuestionCount from '../components/questionCount';
-import Layout from '../components/layout';
-import CountryNameLabel from '../components/countryNameLabel';
+import ProgressBar from './progressBar';
+import QuestionCount from './questionCount';
+import Layout from './layout';
+import CountryNameLabel from './countryNameLabel';
 
 const countryCodes = require('../data/countries.json');
 
-const MapComponent = dynamic(import('../components/mapComponent'),{
+const MapComponent = dynamic(import('./mapComponent'),{
 	ssr: false
 })
 

--- a/components/quizTest.js
+++ b/components/quizTest.js
@@ -5,6 +5,7 @@ import {Row, Col, Button} from 'react-bootstrap';
 
 import QuestionCount from '../components/questionCount';
 import Layout from '../components/layout';
+import CountryNameLabel from '../components/countrynamelabel';
 
 const countryCodes = require('../data/countries.json');
 
@@ -69,9 +70,7 @@ export default function QuizTest (props) {
 
 				<div className="row no-gutters align-items-center mapdiv">
 					<MapComponent lat={props.question.lat} lon={props.question.lon} />
-					<div id="countryName">
-						{countryName}
-					</div>
+					<CountryNameLabel countryName={countryName} />
 					<div className={answerClass}>
 						{answer['answer']}
 					</div>

--- a/components/quizTest.js
+++ b/components/quizTest.js
@@ -3,14 +3,14 @@ import Head from 'next/head';
 import dynamic from 'next/dynamic'
 import {Row, Col, Button} from 'react-bootstrap';
 
-import QuestionCount from '../components/questionCount';
-import Layout from '../components/layout';
-import CountryNameLabel from '../components/countryNameLabel';
+import QuestionCount from './questionCount';
+import Layout from './layout';
+import CountryNameLabel from './countryNameLabel';
 
 const countryCodes = require('../data/countries.json');
 
 
-const MapComponent = dynamic(import('../components/mapComponent'),{
+const MapComponent = dynamic(import('./mapComponent'),{
 	ssr: false
 })
 

--- a/components/quizTest.js
+++ b/components/quizTest.js
@@ -5,7 +5,7 @@ import {Row, Col, Button} from 'react-bootstrap';
 
 import QuestionCount from '../components/questionCount';
 import Layout from '../components/layout';
-import CountryNameLabel from '../components/countrynamelabel';
+import CountryNameLabel from '../components/countryNameLabel';
 
 const countryCodes = require('../data/countries.json');
 

--- a/components/result.js
+++ b/components/result.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Head from 'next/head';
 import Link from 'next/link';
-import Layout from '../components/layout';
-import HeaderComponent from '../components/headerComponent';
+import Layout from './layout';
+import HeaderComponent from './headerComponent';
 import Button from 'react-bootstrap/Button';
 import styled from 'styled-components';
 

--- a/components/resultTest.js
+++ b/components/resultTest.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { Container, Col, Row, Button } from 'react-bootstrap';
 
 import useScriptText from '../hooks/useScriptText';
-import Layout from '../components/layout';
+import Layout from './layout';
  
 export default function StartTest(props) {
 

--- a/styles/global.css
+++ b/styles/global.css
@@ -378,7 +378,9 @@ a {
   left: 10px;
   border-radius: 3px;
   border: 1px solid rgba(0, 0, 0, 0.4);
-  font-family: 'Open Sans', sans-serif;
+  font-family: 'Cabin', sans-serif;
+  font-size: 0.8em;
+  text-transform: uppercase;
 }
 
 /*


### PR DESCRIPTION
Themes the country label overlay introduced in #73, as depicted below, both in the test and the actual mapping game.

Isolated the label to its own component for easier reusability.

<img width="293" alt="Screen Shot 2021-04-08 at 7 09 14 AM" src="https://user-images.githubusercontent.com/6098973/114032355-78ab9280-9839-11eb-98cc-2f1900b05c7e.png">
