### PR TITLE
BLD: adjusted result text

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -51,15 +51,15 @@ export default function Result(props) {
 					<div className="innerMessage">
 						<p className="fact" style={{paddingTop: '.5em'}}>
 							You have mapped {props.userStats.mapped_count} locations in total.</p>
-						<p className="fact"><strong>
-						_</strong>
+						<p className="fact">
+							<hr />
 						</p>
-						<p className="fact" style={{paddingTop: '.5em'}}><strong>
-							{props.fact}</strong></p>
-						<p style={{paddingTop: '.5em'}}>
-						{props.taggedAllLocations ? '🏆 You are a mapping champion! 🗺 You have mapped all of our potential school locations. We will add more shortly, so come back soon.' : 'Help us connect more children to opportunity by mapping more schools.'}
+						<p className="fact" style={{paddingTop: '.5em'}}>
+							<strong>
+							{props.taggedAllLocations ? <div><p style={{textAlign: 'center'}}>🏆&nbsp;&nbsp;You are a mapping champion! 🗺 </p>You have mapped all of our potential school locations. We will add more shortly, come back soon.</div> : props.fact}
+							</strong>
 						</p>
-						{props.taggedAllLocations ? <Button variant="primary" href="https://projectconnect.world" target="_blank" rel="noopener">Visit Project Connect</Button> : <Button variant="primary" href="/mapping">Map More Schools</Button>}
+						{props.taggedAllLocations ? <Button variant="primary" href="https://projectconnect.world" target="_blank" rel="noopener">Visit Project Connect</Button> : <div><p>Help us connect more children to opportunity by mapping more schools</p><Button variant="primary" href="/mapping">Map More Schools</Button></div>}
 					</div>
 				</div>
 		    </Layout>

--- a/components/result.js
+++ b/components/result.js
@@ -56,7 +56,7 @@ export default function Result(props) {
 						</p>
 						<p className="fact" style={{paddingTop: '.5em'}}>
 							<strong>
-							{props.taggedAllLocations ? <div><p style={{textAlign: 'center'}}>🏆&nbsp;&nbsp;You are a mapping champion! 🗺 </p>You have mapped all of our potential school locations. We will add more shortly, come back soon.</div> : props.fact}
+							{props.taggedAllLocations ? <div><p style={{textAlign: 'center'}}>🏆&nbsp;&nbsp;You are a mapping champion! 🗺 </p>You have mapped all of our potential school locations. We will add more shortly, so come back soon.</div> : props.fact}
 							</strong>
 						</p>
 						{props.taggedAllLocations ? <Button variant="primary" href="https://projectconnect.world" target="_blank" rel="noopener">Visit Project Connect</Button> : <div><p>Help us connect more children to opportunity by mapping more schools</p><Button variant="primary" href="/mapping">Map More Schools</Button></div>}


### PR DESCRIPTION
Previously, when a user mapped all schools, the text informing her/him that s/he had mapped all schools was fairly small.

Replaced the second fact on the result screen with the congratulatory message, as depicted below:

![Screen Shot 2021-04-09 at 6 48 44 PM](https://user-images.githubusercontent.com/6098973/114252906-e7d1d580-9964-11eb-9f33-b73c3d8ad691.png)
