### PR TITLE
Add Campaign Overview Page

### DIFF
--- a/pages/api/getCampaignStats/[campaign].js
+++ b/pages/api/getCampaignStats/[campaign].js
@@ -1,0 +1,42 @@
+const { Pool } = require('pg');
+
+const pool = new Pool()
+
+export default async (req, res) => {
+	if (req.method === 'GET') {
+		let taggings = null;
+		let users = null;
+		let schools = null;
+		const campaign = req.query.campaign;
+		
+		try {
+			taggings = await pool.query(`
+				SELECT  count(*) FROM crowdsourcing;`);
+			users = await pool.query(`
+				SELECT  count(*) FROM users;`);
+			schools = await pool.query(`
+				SELECT COUNT(*) FROM (SELECT DISTINCT school_id FROM crowdsourcing) AS temp;`);
+		} catch(e) {
+			console.log(e)
+		}	
+
+
+		let output = null;
+		if(taggings && users && schools) {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'application/json');
+			output = JSON.stringify({
+				taggings: taggings.rows[0].count,
+				users: users.rows[0].count,
+				schools: schools.rows[0].count
+			});
+		} else {
+			res.statusCode = 500
+		}
+		res.end(output);
+	} else {
+		// If it's not a GET request, return 405 - Method Not Allowed
+		res.statusCode = 405;
+		res.end();
+	}
+}

--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -1,0 +1,97 @@
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import Error from 'next/error';
+import Layout from '../../components/layout';
+import HeaderComponent from '../../components/headerComponent';
+import { Container, Col, Row, ProgressBar } from 'react-bootstrap';
+
+const campaigns = {
+	"mapbox": {
+		name: 'Mapbox',
+		users: 1000,
+		schools: 1000,
+		taggings: 10000,
+	}
+}
+
+function numberWithCommas(x) {
+    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+export default function campaign() {
+
+	const router = useRouter()
+  	const { campaign } = router.query
+  	const [stats, setStats] = useState({ taggings: 0, users: 0, schools: 0});
+
+  	useEffect(() => {
+  		async function fetchData() {
+			const result = await fetch(`/api/getCampaignStats/${campaign}`);
+			setStats(await result.json());
+		}
+		fetchData();
+	}, []);
+
+  	if(campaign in campaigns) {
+		return(
+		 	<Layout myClass="intro">
+				<Head>
+					<title>Project Connect</title>
+					<link rel="icon" href="/favicon.ico" />
+					<link href="https://fonts.googleapis.com/css2?family=Cabin&display=swap" rel="stylesheet" />
+				</Head>
+
+				<HeaderComponent inverse={false} />
+
+				<div className="tips">
+					<h1>{campaigns[campaign].name} Campaign</h1>
+				</div>
+
+				<Container fluid>
+					<Row>
+						<h4>Total number of taggings</h4>
+					</Row>
+					<Row>
+						<Col xs={9} style={{paddingTop: '0.5em'}}>
+							<ProgressBar now={stats.taggings/campaigns[campaign].taggings*100} />
+						</Col>
+						<Col className="text-right">
+							<h3>{numberWithCommas(campaigns[campaign].taggings)}</h3>
+						</Col>
+					</Row>
+					<Row>
+						<p>&nbsp;</p>
+					</Row>
+					<Row>
+						<h4>Schools Tagged</h4>
+					</Row>
+					<Row>
+						<Col xs={9} style={{paddingTop: '0.5em'}}>
+							<ProgressBar now={stats.schools/campaigns[campaign].schools*100} />
+						</Col>
+						<Col className="text-right">
+							<h3>{numberWithCommas(campaigns[campaign].schools)}</h3>
+						</Col>
+					</Row>
+					<Row>
+						<p>&nbsp;</p>
+					</Row>
+					<Row>
+						<h4>Users Registered</h4>
+					</Row>
+					<Row>
+						<Col xs={9} style={{paddingTop: '0.5em'}}>
+							<ProgressBar now={stats.users/campaigns[campaign].users*100} />
+						</Col>
+						<Col className="text-right">
+							<h3>{numberWithCommas(campaigns[campaign].users)}</h3>
+						</Col>
+					</Row>
+				</Container>
+			</Layout>
+		);
+	} else {
+		return <Error statusCode='404' />
+	}
+}

--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -50,42 +50,63 @@ export default function campaign() {
 
 				<Container fluid>
 					<Row>
-						<h4>Total number of taggings</h4>
+						<Col>
+							<h4>Total number of taggings</h4>
+						</Col>
 					</Row>
 					<Row>
-						<Col xs={9} style={{paddingTop: '0.5em'}}>
+						<Col xs={7} style={{paddingTop: '0.5em'}}>
 							<ProgressBar now={stats.taggings/campaigns[campaign].taggings*100} />
 						</Col>
 						<Col className="text-right">
-							<h3>{numberWithCommas(campaigns[campaign].taggings)}</h3>
+							<h4>
+								<span style={{color: '#007bff'}}>
+									{numberWithCommas(stats.taggings)}
+								</span>
+								&nbsp;/&nbsp;{numberWithCommas(campaigns[campaign].taggings)}
+							</h4>
 						</Col>
 					</Row>
 					<Row>
 						<p>&nbsp;</p>
 					</Row>
 					<Row>
-						<h4>Schools Tagged</h4>
+						<Col>
+							<h4>Schools Tagged</h4>
+						</Col>
 					</Row>
 					<Row>
-						<Col xs={9} style={{paddingTop: '0.5em'}}>
+						<Col xs={7} style={{paddingTop: '0.5em'}}>
 							<ProgressBar now={stats.schools/campaigns[campaign].schools*100} />
 						</Col>
 						<Col className="text-right">
-							<h3>{numberWithCommas(campaigns[campaign].schools)}</h3>
+							<h4>
+								<span style={{color: '#007bff'}}>
+									{numberWithCommas(stats.schools)}
+								</span>
+								&nbsp;/&nbsp;{numberWithCommas(campaigns[campaign].schools)}
+							</h4>
 						</Col>
 					</Row>
 					<Row>
 						<p>&nbsp;</p>
 					</Row>
 					<Row>
-						<h4>Users Registered</h4>
+						<Col>
+							<h4>Users Registered</h4>
+						</Col>
 					</Row>
 					<Row>
-						<Col xs={9} style={{paddingTop: '0.5em'}}>
+						<Col xs={7} style={{paddingTop: '0.5em'}}>
 							<ProgressBar now={stats.users/campaigns[campaign].users*100} />
 						</Col>
 						<Col className="text-right">
-							<h3>{numberWithCommas(campaigns[campaign].users)}</h3>
+							<h4>
+								<span style={{color: '#007bff'}}>
+									{numberWithCommas(stats.users)}
+								</span>
+								&nbsp;/&nbsp;{numberWithCommas(campaigns[campaign].users)}
+							</h4>
 						</Col>
 					</Row>
 				</Container>


### PR DESCRIPTION
Fixes #72

Adds dynamically-generated page to provide an overview for ongoing campaigns. Currently, one needs to hardcode dictionary with the campaign details at `pages/campaign/[campaign].js`, like so:
```
const campaigns = {
	"mapbox": {
		name: 'Mapbox',
		users: 1000,
		schools: 1000,
		taggings: 10000,
	}
}
```
which then results in a display as follows:

<img width="329" alt="Screen Shot 2021-04-10 at 8 55 24 AM" src="https://user-images.githubusercontent.com/6098973/114274214-9cf2a500-99da-11eb-816b-1c50a2b63bef.png">

ToDo:
- build functionality to filter by campaign in API endpoint, will defer to another PR.