### PR TITLE
BLD: ability to set Teams

### DIFF
--- a/components/headerComponent.js
+++ b/components/headerComponent.js
@@ -43,6 +43,9 @@ const Header = ({ hideSignIn }) => {
     const [session, loading] = useSession()
     const router = useRouter()
 
+    const hostname = typeof window !== 'undefined' && window.location.hostname ? window.location.hostname : '';
+    const callbackUrl = hostname === 'localhost' ? 'http://localhost:3000/profile' : 'https://'+hostname+'/profile';
+
     // Redirect to landing page if on authorized-only page
     const signOutWithRedirect = async () => {
         signout()
@@ -59,7 +62,7 @@ const Header = ({ hideSignIn }) => {
             </Link>
             <Nav style={{ height: 100 + '%' }}>
                 {!session && !loading && !hideSignIn && (
-                    <NavItem onClick={signin}>
+                    <NavItem onClick={signin(null, { callbackUrl: callbackUrl })}>
                         <button className="signin-button">Sign in</button>
                     </NavItem>
                 )}

--- a/db/dbOps.js
+++ b/db/dbOps.js
@@ -89,6 +89,7 @@ async function createTables() {
 			created_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			uuid           TEXT,
+			team           TEXT,
 			PRIMARY KEY (id)
 		);
 	`);

--- a/models/User.js
+++ b/models/User.js
@@ -56,5 +56,9 @@ export const UserSchema = {
             type: 'varchar',
             nullable: true,
         },
+        team: {
+            type: 'varchar',
+            nullable: true,
+        },
     },
 };

--- a/pages/api/getCampaignStats/[campaign].js
+++ b/pages/api/getCampaignStats/[campaign].js
@@ -10,13 +10,15 @@ export default async (req, res) => {
 		
 		try {
 			taggings = await pool.query(`
-				SELECT  count(*) FROM crowdsourcing;`);
+				SELECT count(*)
+					FROM crowdsourcing
+					LEFT JOIN Users ON crowdsourcing.user_id=users.uuid
+					WHERE LOWER(team)=LOWER('${campaign}');`);
 			users = await pool.query(`
-				SELECT  count(*) FROM users;`);
+				SELECT count(*) FROM users WHERE LOWER(team)=LOWER('${campaign}');`);
 		} catch(e) {
 			console.log(e)
-		}	
-
+		}
 
 		let output = null;
 		if(taggings && users) {

--- a/pages/api/getUserTeam/[uuid].js
+++ b/pages/api/getUserTeam/[uuid].js
@@ -1,0 +1,33 @@
+import { validate as uuidValidate } from 'uuid';
+
+const { Pool } = require('pg');
+
+const pool = new Pool()
+
+export default async (req, res) => {
+	if (req.method === 'GET') {
+		let result = null;
+		const user_id = req.query.uuid;
+		if (uuidValidate(user_id)) {
+			try {
+				result = await pool.query(`SELECT  team FROM users WHERE uuid='${user_id}';`);
+			} catch(e) {
+				console.log(e)
+			}	
+		}
+
+		let output = null;
+		if(result) {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'application/json');
+			output = JSON.stringify(result.rows[0])
+		} else {
+			res.statusCode = 500
+		}
+		res.end(output);
+	} else {
+		// If it's not a GET request, return 405 - Method Not Allowed
+		res.statusCode = 405;
+		res.end();
+	}
+}

--- a/pages/api/updateUserTeam.js
+++ b/pages/api/updateUserTeam.js
@@ -1,0 +1,34 @@
+import { validate as uuidValidate } from 'uuid'
+
+const { Pool } = require('pg')
+const pool = new Pool()
+
+export default async (req, res) => {
+    // Allow POST-requests only
+    if (req.method !== 'POST') {
+        res.statusCode = 405
+        res.end()
+    }
+
+    const uuid = req.body.uuid;
+    const team = req.body.team;
+
+    if (!(uuid && uuidValidate(uuid))) {
+        res.statusCode = 400
+        res.end()
+    }
+
+    const query = 'UPDATE users SET team=($1) WHERE uuid=($2);'
+
+    try {
+        await pool.query(query, [team, uuid])
+
+        res.statusCode = 200
+        res.end()
+    } catch (err) {
+        console.log(err.stack)
+
+        res.statusCode = 404
+        res.end()
+    }
+}

--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -42,7 +42,7 @@ export default function campaign() {
 			setStats(await result.json());
 		}
 		fetchData();
-	}, []);
+	}, [campaign]);
 
 
 	return(

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -69,12 +69,12 @@ const UserView = ({ user, signout }) => {
                     <div className="profile-name">{user.name}</div>
                 </div>
                 <Form>
-                    <Form.Group as={Row} controlId="formPlaintextPassword">
-                        <Form.Label column xs="2">
+                    <Form.Group as={Row} noGutters={true} controlId="formPlaintextPassword">
+                        <Form.Label column xs={2}>
                           Team:
                         </Form.Label>
                         { team ?
-                        <Col xs="8">
+                        <Col xs={8}>
                             <Form.Control
                                 as="select"
                                 onChange={handleChange.bind(this)}
@@ -85,7 +85,7 @@ const UserView = ({ user, signout }) => {
                             </Form.Control>
                         </Col>
                         : null}
-                        <Col xs="1" className="pl-0">
+                        <Col xs={1} className="p-0">
                         <img
                             src="/icons/greentick.svg"
                             width="20"

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -85,7 +85,7 @@ const UserView = ({ user, signout }) => {
                             </Form.Control>
                         </Col>
                         : null}
-                        <Col xs={1} className="p-0">
+                        <Col xs={1} className="pl-2">
                         <img
                             src="/icons/greentick.svg"
                             width="20"

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -80,7 +80,7 @@ const UserView = ({ user, signout }) => {
                                 onChange={handleChange.bind(this)}
                                 defaultValue={team}
                             >
-                                <option value="0">Not part of a team</option>
+                                <option value="0">None</option>
                                 <option>Mapbox</option>
                             </Form.Control>
                         </Col>

--- a/public/icons/greentick.svg
+++ b/public/icons/greentick.svg
@@ -1,0 +1,3 @@
+<svg id="Layer_1" style="enable-background:new 0 0 612 792;" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#41AD49;}
+</style><g><path class="st0" d="M562,396c0-141.4-114.6-256-256-256S50,254.6,50,396s114.6,256,256,256S562,537.4,562,396L562,396z    M501.7,296.3l-241,241l0,0l-17.2,17.2L110.3,421.3l58.8-58.8l74.5,74.5l199.4-199.4L501.7,296.3L501.7,296.3z"/></g></svg>

--- a/styles/global.css
+++ b/styles/global.css
@@ -514,3 +514,14 @@ a {
   letter-spacing: 1px;
   color: #ffffff;
 }
+
+.iconVisible { opacity:1; }
+.iconInvisible { opacity:0; }
+.iconFadeOut{
+     opacity:0;
+     transition: opacity 1s 2s;
+}
+.iconFadeIn{
+     opacity:1;
+     transition: opacity 1s 2s;
+}


### PR DESCRIPTION
This PR adds the functionality for the users to add themselves to a team in their profile page:
* a one-field form is added to the `/profile` page with hardcoded values for a select field type, where the user can choose a team
* the above field updates the `users` table in the DB via a new API endpoint (a second API endpoint was created to read the value from that field for a given user)
* a nifty animation is added to visually notify the user that the value has been updated (which then fades out), all using only CSS
* the signin flow is altered with the specification of a callbackUrl so that users are redirected to `/profile` upon signing in. For new users, it will be thus evident to add themselves to a team
* the dynamic `/campaign/[campaign]` page is modified to use the value of the campaign to filter for the results specific to that campaign (it will only show activity from users that have added themselves to that team (where team=campaign)

<img width="250" alt="Screen Shot 2021-04-15 at 1 21 20 AM" src="https://user-images.githubusercontent.com/6098973/114830160-2a424a80-9d89-11eb-8ea0-182dcd452ca0.png">
