### PR TITLE
BUG: fix signin call

### DIFF
--- a/components/headerComponent.js
+++ b/components/headerComponent.js
@@ -62,7 +62,7 @@ const Header = ({ hideSignIn }) => {
             </Link>
             <Nav style={{ height: 100 + '%' }}>
                 {!session && !loading && !hideSignIn && (
-                    <NavItem onClick={signin(null, { callbackUrl: callbackUrl })}>
+                    <NavItem onClick={() => signin(null, { callbackUrl: callbackUrl })}>
                         <button className="signin-button">Sign in</button>
                     </NavItem>
                 )}

--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -11,8 +11,12 @@ const campaigns = {
 	"mapbox": {
 		name: 'Mapbox',
 		users: 1000,
-		schools: 1000,
 		taggings: 10000,
+	},
+	"unicef": {
+		name: 'UNICEF',
+		users: 20,
+		taggings: 500,
 	}
 }
 

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -82,6 +82,7 @@ const UserView = ({ user, signout }) => {
                             >
                                 <option value="0">None</option>
                                 <option>Mapbox</option>
+                                <option>UNICEF</option>
                             </Form.Control>
                         </Col>
                         : null}


### PR DESCRIPTION
A major usability bug was introduced in #85 where a the `signin` call was passed directly to `onClick` instead of a reference to it. This has been fixed in bc2e9f7

Additionally an internal campaign for UNICEF has been set up in 806ff4a