### PR TITLE
BLD: leaderboard in campaign page

### DIFF
--- a/pages/api/summaryUsers.js
+++ b/pages/api/summaryUsers.js
@@ -7,9 +7,23 @@ const pool = new Pool()
 export default async (req, res) => {
 	if (req.method === 'GET') {
 
+		const campaign = req.query.campaign ? req.query.campaign : null;
+		const names = req.query.names ? req.query.names : null;
+
+		let namefield = 'user_id';
+		if(names) {
+			namefield = 'name';
+		}
+		let query = `SELECT ${namefield}, count(user_id) FROM crowdsourcing
+					LEFT JOIN Users ON crowdsourcing.user_id=users.uuid`;
+		if(campaign) {
+			query += ` WHERE LOWER(team)=LOWER('${campaign}')`;
+		}
+		query += ` GROUP BY ${namefield} ORDER BY count DESC`;
+
 		let result = null;
 		try {
-			result = await pool.query('select user_id, count(user_id) from crowdsourcing GROUP BY user_id order by count DESC;');
+			result = await pool.query(query);
 		} catch(e) {
 			console.log(e);
 		}

--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import Error from 'next/error';
 import Layout from '../../components/layout';
 import HeaderComponent from '../../components/headerComponent';
-import { Container, Col, Row, ProgressBar } from 'react-bootstrap';
+import { Container, Col, Row, ProgressBar, Table } from 'react-bootstrap';
 
 
 const campaigns = {
@@ -15,7 +15,7 @@ const campaigns = {
 	},
 	"unicef": {
 		name: 'UNICEF',
-		users: 20,
+		users: 25,
 		taggings: 500,
 	}
 }
@@ -29,6 +29,7 @@ export default function campaign() {
 	const router = useRouter();
 	const [campaign, setCampaign] = useState(null);
   	const [stats, setStats] = useState({ taggings: 0, users: 0, schools: 0});
+    const [leaderboard, setLeaderboard] = useState([]);
 
 	useEffect(() => {
 		if(router.query.campaign) {
@@ -44,6 +45,8 @@ export default function campaign() {
 		async function fetchData() {
 			const result = await fetch(`/api/getCampaignStats/${campaign}`);
 			setStats(await result.json());
+			const leaders = await fetch(`/api/summaryUsers?campaign=${campaign}&names=1`);
+			setLeaderboard(await leaders.json());
 		}
 		fetchData();
 	}, [campaign]);
@@ -104,6 +107,36 @@ export default function campaign() {
 								&nbsp;/&nbsp;{numberWithCommas(campaigns[campaign].users)}
 							</h4>
 						</Col>
+					</Row>
+					<Row>
+						<Col className="text-center mt-5">
+							<h3>Leaderboard</h3>
+						</Col>
+					</Row>
+					<Row>
+						<Table striped>
+							<thead>
+								<tr>
+									<th>User</th>
+									<th className="text-right">Locations</th>
+								</tr>
+							</thead>
+							<tbody>
+								{ leaderboard.length ?
+									leaderboard.map((item, index) =>
+									<tr key={index}>
+										<td>{item.name ? item.name : 'Anonymous'}</td>
+										<td className="text-right">{item.count}</td>
+									</tr>)
+								:
+									<tr>
+										<td colSpan="2" className="text-center p-5">
+											No mapping activity to display yet
+										</td>
+									</tr>
+								}
+							</tbody>
+						</Table>
 					</Row>
 				</Container>
 			</Layout>


### PR DESCRIPTION
- Add leaderboard in `/campaign/[campaign]` page, which displays a table of users and their count of locations mapped. If no users have mapped any location, the table displays an "empty" message.
- Refactor `pages/api/summaryUsers.js` used previously in `/summary` page to accept optional parameters to display usernames instead of user_ids and filter by campaign.

See screenshots:
![Screen Shot 2021-04-15 at 3 21 40 PM](https://user-images.githubusercontent.com/6098973/114940496-26510f80-9dff-11eb-8a35-16ac14134c89.png)

![Screen Shot 2021-04-15 at 3 21 58 PM](https://user-images.githubusercontent.com/6098973/114940546-3832b280-9dff-11eb-85ae-4d6cbefdcde0.png)
