### PR TITLE
Changes "schools" --> "locations"

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -46,7 +46,7 @@ export default function Result(props) {
 					<div className="outerMessage">
 						<img src='Congratulations.svg' alt='Congratulations' />
 						<h2>Congratulations!</h2>
-						<p>You just mapped {props.gameStats.mapped_count} schools</p>
+						<p>You just mapped {props.gameStats.mapped_count} locations</p>
 					</div>
 					<div className="innerMessage">
 						<p className="fact" style={{paddingTop: '.5em'}}>


### PR DESCRIPTION
On the results page, changed "You just mapped 10 schools" to "You just mapped 10 locations" for accuracy.
<img width="515" alt="Screen Shot 2021-04-16 at 11 09 59 AM" src="https://user-images.githubusercontent.com/6993618/115045197-4a1a6100-9ea4-11eb-9ac6-20e5cb71d64c.png">
