### PR TITLE
Increased quiz element padding

### DIFF
--- a/components/progressBar.js
+++ b/components/progressBar.js
@@ -104,9 +104,9 @@ const ProgressBar = props => {
 	return (
 		<Container value={value} answer={answer} width={width} chosen={chosen} label={label} >
 			<div className={chosen == true ? `grid-container bar-chosen ${answer}` : 'grid-container bar-unchosen'}>
-				<span id='label'>{label}&nbsp;</span>
+				<span id='label'>{label}&nbsp;&nbsp;</span>
 				<div><progress id='progress-bar' label={label} value={value} max={max} /></div>
-				<span id='percentage'>&nbsp;{((value / max) * 100).toFixed(2)}%</span>
+				<span id='percentage'>&nbsp;&nbsp;{((value / max) * 100).toFixed(2)}%</span>
 			</div>
 		</Container>);
 }

--- a/components/quiz.js
+++ b/components/quiz.js
@@ -102,6 +102,7 @@ export default function Quiz (props) {
 							chosen={result.answer == 'maybe'} 
 							answer={result.answer}
 							value={((props.locationResults.maybe_count + (result.answer == 'maybe' ? 1 : 0)) / (props.locationResults.total_count + 1)) * 100} />
+						<br/>
 					</div>
 					:
 					''


### PR DESCRIPTION
## What
In response to #93, I have increased padding:
* Above the 'Next' button while user responses are being shown after the user clicks on a response
* To the left and right of the progress bars to provide a tiny bit more room between the bar and the text

## How

I have added a line break before the 'Next' button and some additional whitespace around the progress bar in the ProgressBar element. 

## Tests
<img width="562" alt="Screen Shot 2021-04-21 at 8 11 46 PM" src="https://user-images.githubusercontent.com/6993618/115640990-cdd9b080-a2dd-11eb-8708-7dc13de66e31.png">
