### PR TITLE
BUG: fix selection of locations remaining

### DIFF
--- a/pages/mapping.js
+++ b/pages/mapping.js
@@ -27,7 +27,7 @@ export default function mapping() {
   const [fact, setFact] = useState("");
 
   const [cookies, setCookie] = useCookies(["uuid"]);
-  const [session] = useSession();
+  const [session, loading] = useSession();
 
   const [untaggedLocationsCount, setUntaggedLocationsCount] = useState(10);
 
@@ -45,22 +45,25 @@ export default function mapping() {
       });
     }
 
-    // Initialize cookie if not present
-    const userId = uuidv4();
-    if (!session && !cookies.uuid) {
-      setCookie("uuid", userId, {path: "/", maxAge: 2592000}); // maxAge: 30 days
-      addUser(userId);
-    }
-
-    // Initialize the set of questions
-    async function fetchData() {
+    async function fetchData(userId) {
       const user_id = session ? session.user.id : cookies.uuid ? cookies.uuid : userId;
       // Get location data
       const result = await fetch(`/api/getLocations/${user_id}`);
       setQuestions(await result.json());
     }
-    fetchData();
-  }, []);
+
+    if (!loading) {
+      // Initialize cookie if not present
+      const userId = uuidv4();
+      if (!session && !cookies.uuid) {
+        setCookie("uuid", userId, {path: "/", maxAge: 2592000}); // maxAge: 30 days
+        addUser(userId);
+      }
+
+      // Initialize the set of questions
+      fetchData(userId);
+    }
+  }, [loading]);
 
   async function fetchLocationResults(school_id) {
     // Get number of untagged locations


### PR DESCRIPTION
Fixes unicef/projectconnect-app#11

The bug was caused by loading the locations to be mapped before the `session` had finished loading, thus the user was not properly identified, and locations were instead selected based on another identifier (that is randomly every time). The fix waits for the session to be loaded, and then queries the API with the right identifier associated to the logged in user, thereby resulting in the expected behavior.