### PR TITLE
BUG: fix race condition in display campaigns

### DIFF
--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -29,24 +29,22 @@ export default function campaign() {
   const [leaderboard, setLeaderboard] = useState([]);
 
   useEffect(() => {
+    async function fetchData(campaign) {
+      const result = await fetch(`/api/getCampaignStats/${campaign}`);
+      const leaders = await fetch(`/api/summaryUsers?campaign=${campaign}&names=1`);
+      setStats(await result.json());
+      setLeaderboard(await leaders.json());
+    }
+
     if (router.query.campaign) {
       if (router.query.campaign in campaigns) {
         setCampaign(router.query.campaign);
+        fetchData(router.query.campaign);
       } else {
         router.push("/404");
       }
     }
   }, [router.query]);
-
-  useEffect(() => {
-    async function fetchData() {
-      const result = await fetch(`/api/getCampaignStats/${campaign}`);
-      setStats(await result.json());
-      const leaders = await fetch(`/api/summaryUsers?campaign=${campaign}&names=1`);
-      setLeaderboard(await leaders.json());
-    }
-    fetchData();
-  }, [campaign]);
 
   return (
     <>


### PR DESCRIPTION
Fixes bug that caused race condition in the display of campaign stats, where either no data is shown at all (screenshot below), data is shown momentarily, or only partial data is displayed. I believe the race condition is caused by the async call to setCampaign, where currently fetch data is not dependent on that state variable to be set, but its value from router.query is passed directly to fetch data.

<img width="410" alt="Screen Shot 2021-04-30 at 6 23 48 PM" src="https://user-images.githubusercontent.com/6098973/116765366-ea62a080-a9e1-11eb-963b-7842266d0bf2.png">
