### PR TITLE
Fixed button styling issue on answer

### DIFF
--- a/components/quizTest.js
+++ b/components/quizTest.js
@@ -16,7 +16,9 @@ const MapComponent = dynamic(import("./mapComponent"), {
 export default function QuizTest(props) {
   const [next, setNext] = useState(false);
   const [yes, setYes] = useState("outline-primary");
+  const [yesClass, setYesClass] = useState("yes testButton");
   const [no, setNo] = useState("outline-primary");
+  const [noClass, setNoClass] = useState("no testButton");
   const [result, setResult] = useState(false);
   const [answer, setAnswer] = useState({answer: "", answerClass: "answerHidden"});
 
@@ -24,18 +26,22 @@ export default function QuizTest(props) {
     if (value === props.question.answer) {
       if (value === true) {
         setYes("success");
+        setYesClass("testButton btn-success");
         setAnswer({answer: "Correct answer", answerClass: "answerCorrect"});
       } else {
         setNo("success");
+        setNoClass("testButton btn-success");
         setAnswer({answer: "Correct answer", answerClass: "answerCorrect"});
       }
       setResult(true);
     } else {
       if (value === true) {
         setYes("danger");
+        setYesClass("testButton btn-danger");
         setAnswer({answer: "Incorrect answer", answerClass: "answerIncorrect"});
       } else {
         setNo("danger");
+        setNoClass("testButton btn-danger");
         setAnswer({answer: "Incorrect answer", answerClass: "answerIncorrect"});
       }
       setResult(false);
@@ -46,7 +52,9 @@ export default function QuizTest(props) {
   function handleNext() {
     setNext(false);
     setYes("outline-primary");
+    setYesClass("yes testButton");
     setNo("outline-primary");
+    setNoClass("no testButton");
     setAnswer({answer: "", answerClass: "answerHidden"});
     props.onAnswerSelected(result);
   }
@@ -74,7 +82,7 @@ export default function QuizTest(props) {
             <Col xs={{size: 4, offset: 1}} className="ml-1 pr-0">
               <Button
                 variant={yes}
-                className="yes testButton"
+                className={yesClass}
                 onClick={(e) => handleClick(e, true)}
                 disabled={next}
               >
@@ -84,7 +92,7 @@ export default function QuizTest(props) {
             <Col xs={{size: 4, offset: 2}} className="mr-1 pl-0">
               <Button
                 variant={no}
-                className="no testButton"
+                className={noClass}
                 onClick={(e) => handleClick(e, false)}
                 disabled={next}
               >


### PR DESCRIPTION
There was a slight visibility issue in the "Yes" and "No" buttons in the quiz section. The comparison is shown through screenshots below:
**BEFORE**
![image](https://user-images.githubusercontent.com/55681423/117001675-412cea80-ad00-11eb-9626-bd395edc6027.png)
![image](https://user-images.githubusercontent.com/55681423/117001739-56a21480-ad00-11eb-8b93-fd7165d28f0b.png)

We notice in the above two cases that the Yes and No labels are not properly visible due to the background colour added. 

**AFTER**
![image](https://user-images.githubusercontent.com/55681423/117001975-9d900a00-ad00-11eb-93f4-9321c0f73428.png)
![image](https://user-images.githubusercontent.com/55681423/117002125-c7493100-ad00-11eb-9d31-723923dcd257.png)

The issue has been fixed by changing the class to make the colour of the labels white on answering.