### PR TITLE
BLD: use of constants to manage campaigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,36 @@ Refer to [unicef/projectconnect-app](https://github.com/unicef/projectconnect-ap
 
 This webapp is built using [Next.js](https://nextjs.org/) as a React Framework and deployed using [Vercel](https://vercel.com/).
 
-* `pages/_app.js` is the application entry point:
-    1. Imports the default Bootstrap stylesheet, and additional styles found in `styles/global.css`
-    2. Wraps the application in a `<CookieProvider>` to make available [react-cookie](https://www.npmjs.com/package/react-cookie) throughout the code.
-* `pages/index.js` is the first page to load, which imports `components/intro.js`:
-    1. Landing page includes static content
-    2. links to `pages/start-test.js` and `pages/tips.js`
-    3. Includes FAQ as a Bootstrap accordion.
-* `pages/tips.js` is primarily static content, pulling images from `public/tips/`
-* `pages/start-test.js` is also mostly static content that directs users to `pages/test.js` or `pages/mapping.js`
-* `pages/mapping.js` contains most of the logic for the application:
-    1. Fetches dataset of schools to validate from API endpoint: `pages/api/getLocations/[uuid].js`
-    2. Sets cookie, and adds user to Database (`pages/api/addUser.js`), if cookie is not set
-    3. Presents data through frontend, by calling `components/quiz.js
-    4. Stores user response through API endpoint: `pages/api/validateLocation.js`
-    5. Upon completion, redirects user to `components/result.js`
-* `pages/test.js` is a simplified version of `pages/mapping.js` that instead of pulling data from the database, it pulls local data from `pages/api/quizQuestions.js` and does not store any of the user answers. It calls `components/quizTest.js`, analogous to `components/quiz.js`
-* `components/quiz.js` iterates through the dataset prompting the user to respond to each location. It calls the `component/mapComponent.js` to render the actual map using Mapbox as the provider through [react-mapbox-gl](https://www.npmjs.com/package/react-mapbox-gl) as bindings for [mapbox-gl](https://docs.mapbox.com/mapbox-gl-js/api/)
+- `pages/_app.js` is the application entry point:
+  1. Imports the default Bootstrap stylesheet, and additional styles found in `styles/global.css`
+  2. Wraps the application in a `<CookieProvider>` to make available [react-cookie](https://www.npmjs.com/package/react-cookie) throughout the code.
+- `pages/index.js` is the first page to load, which imports `components/intro.js`:
+  1. Landing page includes static content
+  2. links to `pages/start-test.js` and `pages/tips.js`
+  3. Includes FAQ as a Bootstrap accordion.
+- `pages/tips.js` is primarily static content, pulling images from `public/tips/`
+- `pages/start-test.js` is also mostly static content that directs users to `pages/test.js` or `pages/mapping.js`
+- `pages/mapping.js` contains most of the logic for the application:
+  1. Fetches dataset of schools to validate from API endpoint: `pages/api/getLocations/[uuid].js`
+  2. Sets cookie, and adds user to Database (`pages/api/addUser.js`), if cookie is not set
+  3. Presents data through frontend, by calling `components/quiz.js
+  4. Stores user response through API endpoint: `pages/api/validateLocation.js`
+  5. Upon completion, redirects user to `components/result.js`
+- `pages/test.js` is a simplified version of `pages/mapping.js` that instead of pulling data from the database, it pulls local data from `pages/api/quizQuestions.js` and does not store any of the user answers. It calls `components/quizTest.js`, analogous to `components/quiz.js`
+- `components/quiz.js` iterates through the dataset prompting the user to respond to each location. It calls the `component/mapComponent.js` to render the actual map using Mapbox as the provider through [react-mapbox-gl](https://www.npmjs.com/package/react-mapbox-gl) as bindings for [mapbox-gl](https://docs.mapbox.com/mapbox-gl-js/api/)
+
+## 👊 Launching a New Campaign
+
+When adding a new campaign for a partner, edit [constants/index.js](constants/index.js) and add a new entry in the dictionary, specifying all three fields, namely:
+
+- `name`: The name of the partner or campaign
+- `users`: The targeted number of users to register and participate throughout the campaign
+- `taggings`: The targeted number of location taggings that the campaign aims to reach
 
 ## ✏️ Configuration
 
-In order to run this application, you need to set up a [Postgres Database](https://www.postgresql.org/) and open an account with [Mapbox](https://www.mapbox.com/) to obtain an *Access Token*. The following [environment variables](https://nextjs.org/docs/basic-features/environment-variables) need to be set in `.env` or `.env.local`:
+In order to run this application, you need to set up a [Postgres Database](https://www.postgresql.org/) and open an account with [Mapbox](https://www.mapbox.com/) to obtain an _Access Token_. The following [environment variables](https://nextjs.org/docs/basic-features/environment-variables) need to be set in `.env` or `.env.local`:
+
 ```
 NEXT_PUBLIC_ACCESS_TOKEN="MAPBOX_ACCESS_TOKEN"
 PGUSER="POSTGRES_USER"
@@ -36,7 +45,9 @@ PGHOST="POSTGRES_HOST"
 PGPASSWORD="POSTGRES_PASSWORD"
 PGDATABASE="POSTGRES_DATABASE"
 ```
+
 To work with the authentication functionalities, you need to add the following entries to the `.env` or `.env.local`:
+
 ```
 SECRET="A secret to use for key generation"
 NEXTAUTH_URL="HOST_URL"
@@ -48,13 +59,15 @@ GOOGLE_CLIENT_ID="YOUR_GOOGLE_CLIENT_ID"
 GOOGLE_CLIENT_SECRET="YOUR_GOOGLE_CLIENT_SECRET"
 NEXT_PUBLIC_AUTH_CALLBACK="HOST_URL"
 ```
+
 To obtain the secrets, contact one of the contributors.
 
 The [countries.json](data/countries.json) is included in this repository to associate country codes with country names. If this file needs to be updated or replaced, follow these instructions:
 
 1. Download [the JSON file of country names and ISO-3166 alpha-2 codes here](https://datahub.io/core/country-list) from Data Hub. Place the JSON file in `scripts/` of this repository and call it `countryCodes.json`.
-2. From the root directory, run `node scripts/createCountryCodesJson.js` to run the script that creates the JSON file the game requires and places it in `data/`. 
+2. From the root directory, run `node scripts/createCountryCodesJson.js` to run the script that creates the JSON file the game requires and places it in `data/`.
 3. Verify that the JSON file `countries.json` exists inside `data/` and it is in the format:
+
 ```
 {
     "Country code": "Country name",
@@ -67,58 +80,59 @@ The [countries.json](data/countries.json) is included in this repository to asso
 Setup your development environment as follows:
 
 1. Clone this repo:
-    - SSL:
-    ```bash
-    git clone git@github.com:lacabra/proco-map-app.git
-    ```
-    - HTTPS:
-    ```bash
-    git clone https://github.com/lacabra/proco-map-app.git
-    ```
+   - SSL:
+   ```bash
+   git clone git@github.com:lacabra/proco-map-app.git
+   ```
+   - HTTPS:
+   ```bash
+   git clone https://github.com/lacabra/proco-map-app.git
+   ```
 2. Install project dependencies:
-    ```bash
-    cd proco-map-app
-    npm install
-    ```
+   ```bash
+   cd proco-map-app
+   npm install
+   ```
 3. Set up your local [Postgres Database](https://www.postgresql.org/) and configure the following environment variables in `.env.local`:
-    ```bash
-    NEXTAUTH_URL=http://localhost:3000
-    PGUSER=
-    PGHOST=
-    PGPASSWORD=
-    PGDATABASE=
-    ```
-5. Open an account with [Mapbox](https://www.mapbox.com/) to obtain an *Access Token*. Add your access token to `.env.local`:   
-    ```bash
-    NEXT_PUBLIC_ACCESS_TOKEN="YOUR_MAPBOX_ACCESS_TOKEN"
-    ```
-6. Optional: If you need to test the user authentication, you will need to set up your own credentials with either one of the OAuth providers:
-    * RECOMENDED FOR EASIER SETUP: **GitHub**: Follow these [instructions](https://docs.github.com/en/developers/apps/creating-an-oauth-app).
-        * Homepage URL: `http://localhost:3000`  
-        * Authorization Callback URL: `http://localhost:3000/api/auth/callback/github`
-7. Optional: you may get a [*jwt_auto_generated_signing_key* warning](https://github.com/nextauthjs/next-auth/issues/484) that you can resolve by following the instructions on that link, or [these instructions](https://next-auth.js.org/warnings).
-8. Run the developmnet server with [fast refresh](https://nextjs.org/docs/basic-features/fast-refresh):
-    ```bash
-    npm run dev
-    ```
+   ```bash
+   NEXTAUTH_URL=http://localhost:3000
+   PGUSER=
+   PGHOST=
+   PGPASSWORD=
+   PGDATABASE=
+   ```
+4. Open an account with [Mapbox](https://www.mapbox.com/) to obtain an _Access Token_. Add your access token to `.env.local`:
+   ```bash
+   NEXT_PUBLIC_ACCESS_TOKEN="YOUR_MAPBOX_ACCESS_TOKEN"
+   ```
+5. Optional: If you need to test the user authentication, you will need to set up your own credentials with either one of the OAuth providers:
+   - RECOMENDED FOR EASIER SETUP: **GitHub**: Follow these [instructions](https://docs.github.com/en/developers/apps/creating-an-oauth-app).
+     - Homepage URL: `http://localhost:3000`
+     - Authorization Callback URL: `http://localhost:3000/api/auth/callback/github`
+6. Optional: you may get a [_jwt_auto_generated_signing_key_ warning](https://github.com/nextauthjs/next-auth/issues/484) that you can resolve by following the instructions on that link, or [these instructions](https://next-auth.js.org/warnings).
+7. Run the developmnet server with [fast refresh](https://nextjs.org/docs/basic-features/fast-refresh):
+   ```bash
+   npm run dev
+   ```
 
 ## 🗄 Data Ingestion
 
 This application expects a CSV file containing the following data about each school:
 
-* lat
-* lon
-* id
-* country
+- lat
+- lon
+- id
+- country
 
 Name the file `schools.csv` and copy it into the `scripts/` folder. In that folder run:
+
 ```bash
 node csvToJson.js
 ```
 
 The above script will generate a file `schools.json` that will be ingested by `db/dbOps.js`.
 
-*Note: For testing purposes a sample `scripts/schools.json` is included in the code repository, which has the same data as the locations used in the [practice test](https://github.com/lacabra/proco-map-app/blob/master/pages/api/getLocationsTest.js), yet in production a different dataset will be used.*
+_Note: For testing purposes a sample `scripts/schools.json` is included in the code repository, which has the same data as the locations used in the [practice test](https://github.com/lacabra/proco-map-app/blob/master/pages/api/getLocationsTest.js), yet in production a different dataset will be used._
 
 ## :memo: License
 

--- a/constants/index.js
+++ b/constants/index.js
@@ -1,0 +1,17 @@
+export const CAMPAIGNS = {
+  arm: {
+    name: "Arm",
+    users: 200,
+    taggings: 10000,
+  },
+  mapbox: {
+    name: "Mapbox",
+    users: 200,
+    taggings: 20000,
+  },
+  unicef: {
+    name: "UNICEF",
+    users: 25,
+    taggings: 2000,
+  },
+};

--- a/pages/campaign/[campaign].js
+++ b/pages/campaign/[campaign].js
@@ -4,24 +4,7 @@ import Head from "next/head";
 import Layout from "../../components/layout";
 import HeaderComponent from "../../components/headerComponent";
 import {Container, Col, Row, ProgressBar, Table} from "react-bootstrap";
-
-const campaigns = {
-  mapbox: {
-    name: "Mapbox",
-    users: 200,
-    taggings: 20000,
-  },
-  unicef: {
-    name: "UNICEF",
-    users: 25,
-    taggings: 2000,
-  },
-  arm: {
-    name: "Arm",
-    users: 200,
-    taggings: 10000,
-  },
-};
+import {CAMPAIGNS} from "../../constants";
 
 function numberWithCommas(x) {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
@@ -42,7 +25,7 @@ export default function campaign() {
     }
 
     if (router.query.campaign) {
-      if (router.query.campaign in campaigns) {
+      if (router.query.campaign in CAMPAIGNS) {
         setCampaign(router.query.campaign);
         fetchData(router.query.campaign);
       } else {
@@ -67,7 +50,7 @@ export default function campaign() {
           <HeaderComponent inverse={false} />
 
           <div className="tips">
-            <h1>{campaigns[campaign].name} Campaign</h1>
+            <h1>{CAMPAIGNS[campaign].name} Campaign</h1>
           </div>
 
           <Container fluid>
@@ -79,7 +62,7 @@ export default function campaign() {
             <Row>
               <Col xs={7} style={{paddingTop: "0.5em"}}>
                 <ProgressBar
-                  now={(stats.taggings / campaigns[campaign].taggings) * 100}
+                  now={(stats.taggings / CAMPAIGNS[campaign].taggings) * 100}
                 />
               </Col>
               <Col className="text-right">
@@ -87,7 +70,7 @@ export default function campaign() {
                   <span style={{color: "#007bff"}}>
                     {numberWithCommas(stats.taggings)}
                   </span>
-                  &nbsp;/&nbsp;{numberWithCommas(campaigns[campaign].taggings)}
+                  &nbsp;/&nbsp;{numberWithCommas(CAMPAIGNS[campaign].taggings)}
                 </h4>
               </Col>
             </Row>
@@ -101,12 +84,12 @@ export default function campaign() {
             </Row>
             <Row>
               <Col xs={7} style={{paddingTop: "0.5em"}}>
-                <ProgressBar now={(stats.users / campaigns[campaign].users) * 100} />
+                <ProgressBar now={(stats.users / CAMPAIGNS[campaign].users) * 100} />
               </Col>
               <Col className="text-right">
                 <h4>
                   <span style={{color: "#007bff"}}>{numberWithCommas(stats.users)}</span>
-                  &nbsp;/&nbsp;{numberWithCommas(campaigns[campaign].users)}
+                  &nbsp;/&nbsp;{numberWithCommas(CAMPAIGNS[campaign].users)}
                 </h4>
               </Col>
             </Row>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -8,6 +8,7 @@ import {Image, Button, Form, Row, Col} from "react-bootstrap";
 import Layout from "../components/layout";
 import HeaderComponent from "../components/headerComponent";
 import FooterComponent from "../components/footerComponent";
+import {CAMPAIGNS} from "../constants";
 
 const UserView = ({user, signout}) => {
   const [team, setTeam] = useState(null);
@@ -19,7 +20,7 @@ const UserView = ({user, signout}) => {
     const getUserTeam = async () => {
       const result = await fetch(`/api/getUserTeam/${user.id}`);
       const response = await result.json();
-      setTeam(response.team);
+      setTeam(response.team ? response.team : 0);
     };
 
     const getUserStats = async () => {
@@ -71,7 +72,7 @@ const UserView = ({user, signout}) => {
             <Form.Label column xs={2}>
               Team:
             </Form.Label>
-            {team ? (
+            {team !== null ? (
               <Col xs={8}>
                 <Form.Control
                   as="select"
@@ -79,8 +80,9 @@ const UserView = ({user, signout}) => {
                   defaultValue={team}
                 >
                   <option value="0">None</option>
-                  <option>Mapbox</option>
-                  <option>UNICEF</option>
+                  {Object.keys(CAMPAIGNS).map((key, index) => (
+                    <option key={index}>{CAMPAIGNS[key].name}</option>
+                  ))}
                 </Form.Control>
               </Col>
             ) : null}


### PR DESCRIPTION
This Pull Request fixes a bug and implements an enhancement:
* There was an edge case in which a user with a `null` field in the team column of the users table in the database was not getting the team selector in the UI. This has been fixed
* Definition of campaigns has been refactored in the use of constants, and one canonical source of truth instead of being hardcoded in two different places.